### PR TITLE
To avoid deprecation notices

### DIFF
--- a/DBAL/Type/ImplodedArray.php
+++ b/DBAL/Type/ImplodedArray.php
@@ -60,6 +60,11 @@ abstract class ImplodedArray extends TextType
         return parent::getSQLDeclaration($fieldDeclaration, $platform);
     }
 
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+
     private function assertValueCanBeImploded($value): void
     {
         if (null === $value) {


### PR DESCRIPTION
> The type "oauth2_scope" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. Either set the "commented" attribute in the configuration to "false" or mark the type as commented in "Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Scope::requiresSQLCommentHint()."